### PR TITLE
.1502411993651747:816db19bc918533f7a14b8bb01f81d98_69f1ea83666bfaca1f198a00.69f1ea9d666bfaca1f198a03.69f1ea9dba3f895434b2970e:Trae CN.T(2026/4/29 19:25:17)

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -2,7 +2,7 @@ import Labels from "./Labels";
 import { useBoard } from "@/lib/BoardContext";
 import { MdOutlineCheckBox, MdFormatAlignLeft } from "react-icons/md";
 
-export default function Card({ card }) {
+export default function Card({ card, onDrop, onDragOver }) {
   const { openModal, onDragStart, onDragEnd } = useBoard();
 
   const truncateText = (text, maxLength) => {
@@ -37,6 +37,8 @@ export default function Card({ card }) {
       onClick={() => openModal(card.id)}
       onDragStart={(e) => onDragStart(e, card.id)}
       onDragEnd={onDragEnd}
+      onDrop={onDrop}
+      onDragOver={onDragOver}
       data-card-id={card.id}
     >
       <h3 className="font-medium">{truncateText(card.text, 25)}</h3>

--- a/components/Column.js
+++ b/components/Column.js
@@ -3,16 +3,18 @@ import Card from "./Card";
 import { useBoard } from "@/lib/BoardContext";
 import { FaRegStickyNote } from "react-icons/fa";
 
-export default function Column({ column }) {
+export default function Column({ column, cards: propCards }) {
   const {
-    cards,
     addCard,
-    onCardClick,
     onDragStart,
     onDragEnd,
     onDrop,
     openModal,
+    cards: contextCards,
   } = useBoard();
+  
+  // 使用从props传递的cards，如果没有则使用useBoard中的cards
+  const cards = propCards || contextCards;
 
   const [newText, setNewText] = useState("test");
 
@@ -50,13 +52,16 @@ export default function Column({ column }) {
       <div className="flex-1 overflow-y-auto max-h-[70vh] overflow-show">
         {cards
           .filter((card) => card.columnId === column.id)
+          .sort((a, b) => a.order - b.order)
           .map((card) => (
             <Card
               key={card.id}
               card={card}
-              onClick={onCardClick}
+              onClick={openModal}
               onDragStart={onDragStart}
               onDragEnd={onDragEnd}
+              onDrop={(e) => onDrop(e, column.id, card.id)}
+              onDragOver={(e) => e.preventDefault()}
             />
           ))}
       </div>

--- a/components/board/BoardContent.js
+++ b/components/board/BoardContent.js
@@ -15,7 +15,7 @@ export default function BoardContent({
           <Column
             key={col.id}
             column={col}
-            cards={cards.filter((c) => c.columnId === col.id)}
+            cards={cards}
             handlers={handlers}
           />
         ))}

--- a/lib/BoardContext.js
+++ b/lib/BoardContext.js
@@ -10,13 +10,14 @@ export const BoardProvider = ({ children }) => {
     { id: "done", title: "Done" },
   ]);
   const [cards, setCards] = useState([
-    { id: "1", text: "Task 1", columnId: "todo", labels: ["1"] },
+    { id: "1", text: "Task 1", columnId: "todo", labels: ["1"], order: 1 },
     {
       id: "2",
       text: "Task 2",
       columnId: "in-progress",
       labels: ["2"],
       description: "This is a description!",
+      order: 1,
     },
     {
       id: "3",
@@ -24,6 +25,7 @@ export const BoardProvider = ({ children }) => {
       columnId: "done",
       labels: [],
       description: "# MARKDOWN SUPPORT!",
+      order: 1,
     },
   ]);
   const [modalCardId, setModalCardId] = useState(null);
@@ -42,7 +44,11 @@ export const BoardProvider = ({ children }) => {
 
   const addCard = (columnId, text) => {
     const id = generateId(cards.map((card) => card.id));
-    setCards((prev) => [...prev, { id, text, columnId, labels: [] }]);
+    const columnCards = cards.filter((card) => card.columnId === columnId);
+    const maxOrder = columnCards.length > 0 
+      ? Math.max(...columnCards.map((card) => card.order)) 
+      : 0;
+    setCards((prev) => [...prev, { id, text, columnId, labels: [], order: maxOrder + 1 }]);
     return id;
   };
 
@@ -71,14 +77,60 @@ export const BoardProvider = ({ children }) => {
     setDraggedId(null);
   };
 
-  const onDrop = (e, newColumnId) => {
+  const onDrop = (e, newColumnId, targetCardId = null) => {
     e.preventDefault();
     if (!draggedId) return;
-    setCards((prev) =>
-      prev.map((card) =>
-        card.id === draggedId ? { ...card, columnId: newColumnId } : card
-      )
-    );
+    
+    setCards((prev) => {
+      const draggedCard = prev.find(card => card.id === draggedId);
+      if (!draggedCard) return prev;
+      
+      // 如果是跨列移动
+      if (draggedCard.columnId !== newColumnId) {
+        const columnCards = prev.filter(card => card.columnId === newColumnId);
+        const maxOrder = columnCards.length > 0 
+          ? Math.max(...columnCards.map(card => card.order)) 
+          : 0;
+        
+        return prev.map(card => {
+          if (card.id === draggedId) {
+            return { ...card, columnId: newColumnId, order: maxOrder + 1 };
+          }
+          return card;
+        });
+      }
+      
+      // 如果是同一列内排序
+      if (targetCardId) {
+        const targetCard = prev.find(card => card.id === targetCardId);
+        if (!targetCard) return prev;
+        
+        const columnCards = prev.filter(card => card.columnId === newColumnId);
+        const sortedCards = [...columnCards].sort((a, b) => a.order - b.order);
+        
+        const draggedIndex = sortedCards.findIndex(card => card.id === draggedId);
+        const targetIndex = sortedCards.findIndex(card => card.id === targetCardId);
+        
+        if (draggedIndex === -1 || targetIndex === -1) return prev;
+        
+        // 重新计算order
+        return prev.map(card => {
+          if (card.columnId !== newColumnId) return card;
+          
+          const currentIndex = sortedCards.findIndex(c => c.id === card.id);
+          if (currentIndex === draggedIndex) {
+            return { ...card, order: targetIndex + 1 };
+          } else if (draggedIndex < targetIndex && currentIndex > draggedIndex && currentIndex <= targetIndex) {
+            return { ...card, order: card.order - 1 };
+          } else if (draggedIndex > targetIndex && currentIndex >= targetIndex && currentIndex < draggedIndex) {
+            return { ...card, order: card.order + 1 };
+          }
+          return card;
+        });
+      }
+      
+      return prev;
+    });
 
     setDraggedId(null);
   };


### PR DESCRIPTION
修复卡片拖拽后刷新页面顺序丢失的问题。

为卡片补充排序字段，并在渲染时按排序值展示；拖拽调整顺序后会更新卡片顺序并通过 localStorage 保存，同时保留跨列移动和新增卡片逻辑。